### PR TITLE
docs: fix screenshot description grammar

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This guide explains how to set up and run the simulation, describes each simulat
 We can see the drone is on his way back to the recharge station:
 ![screenshot1](screenshot1.png)
 
-We can see how many insects the drone killing in a 9 hour window (with the current settings):
+We can see how many insects the drone kills in a 9 hour window (with the current settings):
 ![screenshot2](screenshot2.png)
 
 Click [here](https://www.youtube.com/watch?v=hrJzrAwy-MY) to watch a video


### PR DESCRIPTION
## Summary
- fix grammar in screenshot description by replacing "the drone killing" with "the drone kills"

## Testing
- `python -m py_compile drone_energy_simulation.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a4b9a29ab08330bbbdc6886e81c8a7